### PR TITLE
Fix for ZenUI audio

### DIFF
--- a/roms/9/ZenUI/make.sh
+++ b/roms/9/ZenUI/make.sh
@@ -8,3 +8,7 @@ echo "ro.bluetooth.library_name=libbluetooth_qti.so" >> $1/build.prop
 
 # Custom files
 cp -fpr $thispath/lib64/* $1/lib64/
+
+# For Fix Audio
+cat $thispath/rw-system.add.sh >> $1/bin/rw-system.sh
+

--- a/roms/9/ZenUI/rw-system.add.sh
+++ b/roms/9/ZenUI/rw-system.add.sh
@@ -1,2 +1,2 @@
-model="$(sed -n 's/^ro.build.product=[[:space:]]*//p' /system/build.prop)"\
+model="$(sed -n 's/^ro.build.product=[[:space:]]*//p' /system/build.prop)"
 mount -o bind /vendor/etc/audio_policy_configuration.xml /vendor/etc/audio_policy_configuration_"$model".xml || true

--- a/roms/9/ZenUI/rw-system.add.sh
+++ b/roms/9/ZenUI/rw-system.add.sh
@@ -1,0 +1,2 @@
+model="$(sed -n 's/^ro.build.product=[[:space:]]*//p' /system/build.prop)"\
+mount -o bind /vendor/etc/audio_policy_configuration.xml /vendor/etc/audio_policy_configuration_"$model".xml || true


### PR DESCRIPTION
ZenUI has a own audio policy for each device, different of AOSP and others roms, that use a default audio_policy xml.
When we use a not correctly patched vendor, system may not recognize audio volumes, earphones. etc, maintaining only the loudspeaker at max volume.

So lets bind default audio policy, for a correct XML parsing