### PR TITLE
OxygenOS: RIL Fix

### DIFF
--- a/roms/10/OxygenOS/debloat.sh
+++ b/roms/10/OxygenOS/debloat.sh
@@ -46,3 +46,6 @@ rm -rf $1/reserve/JD
 rm -rf $1/reserve/Meituan
 rm -rf $1/reserve/NeteaseCloudmusic
 rm -rf $1/reserve/NeteaseMail
+
+# RIL FIX
+rm -rf $1/product/framework/op-telephony-common.jar


### PR DESCRIPTION
- We Don't need Esports mode injection. 

Co-authored-by: amackpro <48667677+amackpro@users.noreply.github.com>