### PR TITLE
Update setup.sh : fix installation of pip in non-arch linux

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,10 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
        sudo pacman -S --needed unace unrar zip unzip p7zip sharutils uudeview arj cabextract file-roller dtc xz python-pip brotli lz4 gawk libmpack aria2
        #aur=rar
     else
-       sudo apt install unace unrar zip unzip p7zip-full p7zip-rar sharutils rar uudeview mpack arj cabextract file-roller device-tree-compiler liblzma-dev python-pip brotli liblz4-tool gawk aria2
+	   sudo apt install unace unrar zip unzip p7zip-full p7zip-rar sharutils rar uudeview mpack arj cabextract file-roller device-tree-compiler liblzma-dev brotli liblz4-tool gawk aria2
+	   #uncomment the below line to enable the universe repository, in case python2 is not installed already
+	   #sudo add-apt-repository universe && sudo apt update && sudo apt install python2
+	   curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py && sudo python2 get-pip.py && rm get-pip.py
     fi
     pip install backports.lzma protobuf pycrypto
 elif [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
fixes "unable to locate package" for python-pip, by fetching the get-pip.py file, using curl, from "https://bootstrap.pypa.io/get-pip.py"
These fixes are required after python2's "python-pip" went obsolete & missing from packages list.