### PR TITLE
setup.sh: Fix issue with backports.lzma

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
        sudo pacman -S --needed unace unrar zip unzip p7zip sharutils uudeview arj cabextract file-roller dtc xz python-pip brotli lz4 gawk libmpack aria2
        #aur=rar
     else
-       sudo apt install unace unrar zip unzip p7zip-full p7zip-rar sharutils rar uudeview mpack arj cabextract file-roller device-tree-compiler liblzma-dev python-pip brotli liblz4-tool gawk aria2
+       sudo apt install unace unrar build-essential zip unzip p7zip-full p7zip-rar sharutils rar uudeview mpack arj cabextract file-roller device-tree-compiler liblzma-dev python-pip brotli liblz4-tool gawk aria2
     fi
     pip install backports.lzma protobuf pycrypto
 elif [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
When the gcc isn't installed, the pip give error about that.

Co-authored-by: electimon <electimon@gmail.com>