### PR TITLE
fix: Failed to build backports.lzma pycrypto

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -9,8 +9,8 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     else
        sudo apt install unace unrar zip unzip p7zip-full p7zip-rar sharutils rar uudeview mpack arj cabextract file-roller device-tree-compiler liblzma-dev python-pip brotli liblz4-tool gawk aria2
     fi
-    pip install backports.lzma protobuf pycrypto
+    pip install wheel backports.lzma protobuf pycrypto
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     brew install protobuf xz brotli lz4 aria2
-    pip install backports.lzma protobuf pycrypto
+    pip install wheel backports.lzma protobuf pycrypto
 fi


### PR DESCRIPTION
Fixes wheel for backports.lzma and pycrypto.

Full warning:

```
Running setup.py bdist_wheel for backports.lzma: finished with status 'error'
  Failed building wheel for backports.lzma
  Complete output from command /usr/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-xUp4i8/backports.lzma/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmpmN8siQpip-wheel- --python-tag cp27:
  This is backports.lzma version 0.0.14
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help
  
  error: invalid command 'bdist_wheel'
  
  ----------------------------------------
  Running setup.py clean for backports.lzma
  Running setup.py bdist_wheel for pycrypto: started
  Running setup.py bdist_wheel for pycrypto: finished with status 'error'
  Complete output from command /usr/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-xUp4i8/pycrypto/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmpZNQMHfpip-wheel- --python-tag cp27:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help
  
  error: invalid command 'bdist_wheel'
  
  ----------------------------------------
  Failed building wheel for pycrypto
  Running setup.py clean for pycrypto
Failed to build backports.lzma pycrypto
```