### PR TITLE
use ID_LIKE to recognize base linux distro

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,8 @@
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
     distro=$(awk -F= '$1 == "ID" {print $2}' /etc/os-release)
-    if [[ "$distro" == "arch" ]]; then
+    id_like=$(awk -F= '$1 == "ID_LIKE" {print $2}' /etc/os-release)
+    if [[ "$distro" == "arch" || "$id_like" == "arch" ]]; then
        echo "Arch Linux Detected"
        sudo pacman -S --needed unace unrar zip unzip p7zip sharutils uudeview arj cabextract file-roller dtc xz python-pip brotli lz4 gawk libmpack aria2
        #aur=rar


### PR DESCRIPTION
(/etc/os-release) In some distros the value of ID equal to the name
of that distro, for example in manjaro and kde neon, ID is equal to manjaro
and neon respectively
so use the ID and ID_LIKE both to check if the distro is arch based or not

Signed-off-by: nit-in <nit_in@live.com>