### PR TITLE
this is to fix github actions error

### DIFF
--- a/url2GSI.sh
+++ b/url2GSI.sh
@@ -112,6 +112,12 @@ LEAVE()
     exit 1
 }
 
+BYE(){
+
+	echo "Script ran successfully..."
+	exit 0
+}
+
 echo "Updating tools..."
 "$PROJECT_DIR"/update.sh
 
@@ -168,4 +174,4 @@ echo "OTHER = ${@}"
 echo "ZIP_NAME = ${ZIP_NAME}"
 fi
 
-LEAVE
+BYE


### PR DESCRIPTION
the LEAVE function is being used for stopping the script gracefully
but it is also being used in the end for exiting after script have ran successfully,
this might not break the build in local host but causing an error in Github actions
as the script exits with exit 1, which is considered as failure (in bash) even when the output gsi image is created successfully,
this https://github.com/nit-in/erfan_gsi_mmx_6746/actions/runs/1206555548 run might give an idea
as the gsi is created but workflow fails
Solution: using other function BYE or exit 0 at the end

Signed-off-by: nit-in <nit_in@live.com>