### PR TITLE
prebuilt: 12: Don't write binary XML files

### DIFF
--- a/prebuilt/12/make.sh
+++ b/prebuilt/12/make.sh
@@ -64,6 +64,9 @@ echo "ro.lmk.use_minfree_levels=true" >> $1/product/etc/build.prop
 rm -rf $1/etc/init/bpfloader.rc
 echo "bpf.progs_loaded=1" >> $1/product/etc/build.prop
 
+# Don't write binary XML files
+echo "persist.sys.binary_xml=false" >> $1/build.prop
+
 # Bypass SF validateSysprops
 echo "ro.surface_flinger.vsync_event_phase_offset_ns=-1" >> $1/product/etc/build.prop
 echo "ro.surface_flinger.vsync_sf_event_phase_offset_ns=-1" >> $1/product/etc/build.prop


### PR DESCRIPTION
- Android 12 now writes XML files in binary format by default. This can cause incompatibility with TWRP which can hang when attempting to read XML files e.g. /data/system/storage.xml

- This commit sets the persist.sys.binary_xml property to false so that XML files are written in text format.

Change-Id: Ied411e4af8b5943dd5340c25487db475406d354b
Signed-off-by: Velosh <daffetyxd@gmail.com>