### PR TITLE
prebuilt: 12: Extract apexes

### DIFF
--- a/prebuilt/12/make.sh
+++ b/prebuilt/12/make.sh
@@ -5,8 +5,8 @@ romdir=$2
 thispath=`cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd`
 
 # Deal with non-flattened apex
-#$thispath/../../scripts/apex_extractor.sh $1/apex
-#$thispath/../../scripts/apex_extractor.sh $1/system_ext/apex
+$thispath/../../scripts/apex_extractor.sh $1/apex
+$thispath/../../scripts/apex_extractor.sh $1/system_ext/apex
 echo "ro.apex.updatable=true" >> $1/product/etc/build.prop
 
 # Copy system files


### PR DESCRIPTION
* Google's apex tool (deapexer.py, I mean) can deal with .apex/.capex (and it's symlink) fine, so there's no reason to have apex extractor script nuked.